### PR TITLE
Board membership and RBAC: join/leave APIs, joined-workspace boards endpoint, docs and typing improvements

### DIFF
--- a/.kilocode/rules/memory-bank/architecture.md
+++ b/.kilocode/rules/memory-bank/architecture.md
@@ -90,6 +90,13 @@ src/
 - **Role-based Access**: Admin/Normal roles across workspaces and boards
 - **Data Hierarchy**: Workspaces → Boards → Columns → Cards
 
+### 5. Role-Based Access Control (RBAC)
+
+- **Granular Permissions**: Fine-grained permissions for workspaces and boards
+- **Permission Inheritance**: Board roles can inherit from workspace roles
+- **Explicit Overrides**: Board-level roles can override workspace-level roles
+- **Middleware Integration**: RBAC checks integrated into route middleware chains
+
 ## Design Patterns
 
 ### 1. Service Layer Pattern
@@ -141,6 +148,21 @@ router.put(
 )
 ```
 
+### 5. RBAC Middleware Pattern
+
+```typescript
+router.put(
+  '/:workspace_id',
+  accessTokenValidator,
+  verifiedUserValidator,
+  workspaceIdValidator,
+  updateWorkspaceValidator,
+  filterMiddleware<UpdateWorkspaceReqBody>(['title', 'description', 'type', 'logo']),
+  requireWorkspacePermission(WorkspacePermission.ManageWorkspace), // RBAC check
+  wrapRequestHandler(updateWorkspaceController)
+)
+```
+
 ## Component Relationships
 
 ### 1. Authentication Flow
@@ -173,6 +195,12 @@ Upload → Temp Storage → Sharp Processing → UploadThing → Cleanup
 Workspace Operation → Board Impact → Column Impact → Card Impact
 ```
 
+### 6. RBAC Permission Flow
+
+```
+Request → Authentication → Resource Validation → RBAC Check → Controller
+```
+
 ## Critical Implementation Paths
 
 ### 1. User Registration Flow
@@ -180,7 +208,8 @@ Workspace Operation → Board Impact → Column Impact → Card Impact
 ```
 POST /auth/register → registerValidator → registerController →
 authService.register() → User.schema → database.users.insertOne() →
-sendVerifyEmail() → JWT generation → Cookie setting
+sendVerifyEmail() → JWT generation → Cookie setting →
+Auto-create workspace
 ```
 
 ### 2. Workspace Creation Flow
@@ -259,6 +288,20 @@ cardsService.reactCardComment() → MongoDB positional update →
 Reaction management → Socket broadcast → Real-time updates
 ```
 
+### 11. RBAC Permission Check Flow
+
+```
+Route Access → Authentication → Resource Validation →
+RBAC Middleware → Permission Check → Controller
+```
+
+### 12. Invitation Flow
+
+```
+POST /invitations/workspace → Authentication → Validation →
+Invitation Creation → Email Sending → Database Storage
+```
+
 ## Error Handling Architecture
 
 ### 1. Centralized Error Handler
@@ -317,6 +360,13 @@ export class ErrorWithStatus extends Error {
 - **Workspace Roles**: Admin/Normal permissions within workspaces
 - **Board Access**: Workspace membership determines board access
 - **Resource Authorization**: Middleware validates user permissions
+- **Granular Permissions**: Fine-grained control over actions
+
+### 4. RBAC Security
+
+- **Permission-based Access**: Actions require specific permissions
+- **Inheritance Model**: Roles inherit permissions from parent roles
+- **Explicit Overrides**: Fine-grained control at resource level
 
 ## External Service Integration
 
@@ -334,4 +384,4 @@ export const sendVerifyRegisterEmail = async (email: string, token: string) => {
 }
 ```
 
-This architecture ensures maintainability, scalability, and clear separation of concerns while following established Node.js and Express.js best practices. The enhanced workspace management system provides enterprise-grade organizational capabilities while maintaining architectural consistency.
+This architecture ensures maintainability, scalability, and clear separation of concerns while following established Node.js and Express.js best practices. The enhanced workspace management system provides enterprise-grade organizational capabilities while maintaining architectural consistency. The RBAC system adds fine-grained access control for secure collaboration.

--- a/.kilocode/rules/memory-bank/brief.md
+++ b/.kilocode/rules/memory-bank/brief.md
@@ -129,6 +129,8 @@ TrellOne API is a modern, collaborative project management backend system inspir
 - ✅ **File Management**: Image processing and external storage integration
 - ✅ **Email System**: Professional email delivery with HTML templates
 - ✅ **Comment System**: Full commenting with emoji reactions
+- ✅ **Role-Based Access Control**: Fine-grained permissions with inheritance model
+- ✅ **Invitation System**: Workspace and board invitations with email notifications
 
 ### Technical Readiness
 

--- a/.kilocode/rules/memory-bank/context.md
+++ b/.kilocode/rules/memory-bank/context.md
@@ -4,7 +4,7 @@
 
 **Project Status**: PRODUCTION-READY ✅
 
-**Last Updated**: January 2025
+**Last Updated**: August 2025
 
 The TrellOne API has reached stable, production-ready status with all core functionality implemented and operational. All major features are complete and follow established patterns with comprehensive workspace management system fully integrated.
 
@@ -19,6 +19,8 @@ The TrellOne API has reached stable, production-ready status with all core funct
 - **File Upload System**: Sharp processing, UploadThing integration, automatic cleanup
 - **Email System**: Resend integration with HTML templates for all workflows
 - **Card Deletion**: Complete card deletion functionality with proper cleanup and authorization
+- **Role-Based Access Control**: Comprehensive RBAC system with inheritance model and explicit overrides
+- **Invitation System**: Workspace and board invitations with email notifications
 
 ### Technical Stabilization
 
@@ -222,7 +224,7 @@ The codebase is in excellent condition for:
 
 ## Summary
 
-TrellOne API is currently in a **stable, production-ready state** with all core functionality implemented and operational, enhanced with a comprehensive **Workspace Management System**. The project maintains excellent code quality with comprehensive development patterns and is well-positioned for:
+TrellOne API is currently in a **stable, production-ready state** with all core functionality implemented and operational, enhanced with a comprehensive **Workspace Management System** and **Role-Based Access Control**. The project maintains excellent code quality with comprehensive development patterns and is well-positioned for:
 
 1. **Immediate Production Deployment** with enhanced organizational hierarchy
 2. **Continued Feature Development** with solid workspace foundation

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -116,7 +116,8 @@ export const BOARDS_MESSAGES = {
   UPDATE_BOARD_SUCCESS: 'Board updated successfully',
   CANNOT_REMOVE_LAST_BOARD_ADMIN: 'Cannot remove the last admin from board. At least one admin must remain.',
   LEAVE_BOARD_SUCCESS: 'Leave board successfully',
-  USER_NOT_MEMBER_OF_BOARD: 'User is not a member of this board'
+  USER_NOT_MEMBER_OF_BOARD: 'User is not a member of this board',
+  GET_JOINED_WORKSPACE_BOARDS_SUCCESS: 'Get joined workspace boards successfully'
 }
 
 export const COLUMNS_MESSAGES = {

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -86,7 +86,9 @@ export const WORKSPACES_MESSAGES = {
   BOARD_ID_IS_REQUIRED: 'Board id is required for remove from board action',
   BOARD_NOT_FOUND: 'Board not found or does not belong to this workspace',
   USER_NOT_MEMBER_OF_BOARD: 'User is not a member of this board',
-  CANNOT_REMOVE_LAST_BOARD_ADMIN: 'Cannot remove the last admin from board. At least one admin must remain.'
+  CANNOT_REMOVE_LAST_BOARD_ADMIN: 'Cannot remove the last admin from board. At least one admin must remain.',
+  USER_ALREADY_JOINED_BOARD: 'User is already a member of this board',
+  JOIN_WORKSPACE_BOARD_SUCCESS: 'Join workspace board successfully'
 }
 
 export const BOARDS_MESSAGES = {
@@ -111,7 +113,10 @@ export const BOARDS_MESSAGES = {
   COVER_PHOTO_MUST_BE_STRING: 'Cover photo must be a string',
   COVER_PHOTO_LENGTH_MUST_BE_BETWEEN_1_AND_400: 'Cover photo length must be between 1 and 400 characters',
   INVALID_COLUMN_ID: 'Invalid column id',
-  UPDATE_BOARD_SUCCESS: 'Board updated successfully'
+  UPDATE_BOARD_SUCCESS: 'Board updated successfully',
+  CANNOT_REMOVE_LAST_BOARD_ADMIN: 'Cannot remove the last admin from board. At least one admin must remain.',
+  LEAVE_BOARD_SUCCESS: 'Leave board successfully',
+  USER_NOT_MEMBER_OF_BOARD: 'User is not a member of this board'
 }
 
 export const COLUMNS_MESSAGES = {
@@ -254,5 +259,6 @@ export const INVITATIONS_MESSAGES = {
   BOARD_INVITATION_NOT_FOUND: 'Board invitation not found',
   USER_DOES_NOT_HAVE_ACCESS_TO_BOARD_INVITATION: 'User does not have access to this board invitation',
   UPDATE_WORKSPACE_INVITATION_SUCCESS: 'Update workspace invitation successfully',
-  UPDATE_BOARD_INVITATION_SUCCESS: 'Update board invitation successfully'
+  UPDATE_BOARD_INVITATION_SUCCESS: 'Update board invitation successfully',
+  USER_NOT_MEMBER_OF_BOARD: 'User is not a member of this board'
 }

--- a/src/constants/permissions.ts
+++ b/src/constants/permissions.ts
@@ -6,7 +6,8 @@ export enum WorkspacePermission {
   ManageWorkspace = 'WORKSPACE__MANAGE',
   ManageMembers = 'WORKSPACE__MANAGE_MEMBERS',
   ManageGuests = 'WORKSPACE__MANAGE_GUESTS',
-  DeleteWorkspace = 'WORKSPACE__DELETE'
+  DeleteWorkspace = 'WORKSPACE__DELETE',
+  JoinWorkspaceBoard = 'WORKSPACE__JOIN_BOARD'
 }
 
 export enum BoardPermission {
@@ -30,9 +31,14 @@ export const WORKSPACE_ROLE_PERMISSIONS: Record<WorkspaceRole, WorkspacePermissi
     WorkspacePermission.ManageWorkspace,
     WorkspacePermission.ManageMembers,
     WorkspacePermission.ManageGuests,
-    WorkspacePermission.DeleteWorkspace
+    WorkspacePermission.DeleteWorkspace,
+    WorkspacePermission.JoinWorkspaceBoard
   ],
-  [WorkspaceRole.Normal]: [WorkspacePermission.ViewWorkspace, WorkspacePermission.CreateBoard]
+  [WorkspaceRole.Normal]: [
+    WorkspacePermission.ViewWorkspace,
+    WorkspacePermission.CreateBoard,
+    WorkspacePermission.JoinWorkspaceBoard
+  ]
 }
 
 export const BOARD_ROLE_PERMISSIONS: Record<BoardRole, BoardPermission[]> = {

--- a/src/controllers/boards.controllers.ts
+++ b/src/controllers/boards.controllers.ts
@@ -39,3 +39,12 @@ export const updateBoardController = async (req: Request<BoardParams, any, Updat
   const result = await boardsService.updateBoard(board_id, req.body)
   return res.json({ message: BOARDS_MESSAGES.UPDATE_BOARD_SUCCESS, result })
 }
+
+export const leaveBoardController = async (req: Request<BoardParams>, res: Response) => {
+  const { board_id } = req.params
+  const { user_id } = req.decoded_authorization as TokenPayload
+
+  const result = await boardsService.leaveBoard(board_id, user_id)
+
+  return res.json({ message: BOARDS_MESSAGES.LEAVE_BOARD_SUCCESS, result })
+}

--- a/src/controllers/boards.controllers.ts
+++ b/src/controllers/boards.controllers.ts
@@ -1,7 +1,13 @@
 import { Request, Response } from 'express'
 import { ParamsDictionary } from 'express-serve-static-core'
 import { BOARDS_MESSAGES } from '~/constants/messages'
-import { BoardParams, BoardQuery, CreateBoardReqBody, UpdateBoardReqBody } from '~/models/requests/Board.requests'
+import {
+  BoardParams,
+  BoardQuery,
+  CreateBoardReqBody,
+  JoinedWorkspaceBoardQuery,
+  UpdateBoardReqBody
+} from '~/models/requests/Board.requests'
 import { TokenPayload } from '~/models/requests/User.requests'
 import boardsService from '~/services/boards.services'
 
@@ -20,6 +26,28 @@ export const getBoardsController = async (req: Request<ParamsDictionary, any, an
 
   return res.json({
     message: BOARDS_MESSAGES.GET_BOARDS_SUCCESS,
+    result: {
+      boards: result.boards,
+      limit,
+      page,
+      total_page: Math.ceil(result.total / limit)
+    }
+  })
+}
+
+export const getJoinedWorkspaceBoardsController = async (
+  req: Request<ParamsDictionary, any, any, JoinedWorkspaceBoardQuery>,
+  res: Response
+) => {
+  const { workspace_id } = req.params
+  const user_id = req.decoded_authorization?.user_id as string
+  const limit = Number(req.query.limit)
+  const page = Number(req.query.page)
+
+  const result = await boardsService.getJoinedWorkspaceBoards({ workspace_id, user_id, limit, page })
+
+  return res.json({
+    message: BOARDS_MESSAGES.GET_JOINED_WORKSPACE_BOARDS_SUCCESS,
     result: {
       boards: result.boards,
       limit,

--- a/src/controllers/cards.controllers.ts
+++ b/src/controllers/cards.controllers.ts
@@ -58,7 +58,7 @@ export const updateCardCommentController = async (
   return res.json({ message: CARDS_MESSAGES.UPDATE_CARD_COMMENT_SUCCESS, result })
 }
 
-export const removeCardCommentController = async (req: Request<CardCommentParams, any, any>, res: Response) => {
+export const removeCardCommentController = async (req: Request<CardCommentParams>, res: Response) => {
   const { card_id, comment_id } = req.params
 
   const result = await cardsService.removeCardComment(card_id, comment_id)
@@ -89,7 +89,7 @@ export const updateCardAttachmentController = async (
   return res.json({ message: CARDS_MESSAGES.UPDATE_CARD_ATTACHMENT_SUCCESS, result })
 }
 
-export const removeCardAttachmentController = async (req: Request<CardAttachmentParams, any, any>, res: Response) => {
+export const removeCardAttachmentController = async (req: Request<CardAttachmentParams>, res: Response) => {
   const { card_id, attachment_id } = req.params
 
   const result = await cardsService.removeAttachment(card_id, attachment_id)
@@ -105,7 +105,7 @@ export const addCardMemberController = async (req: Request<CardParams, any, AddC
   return res.json({ message: CARDS_MESSAGES.ADD_CARD_MEMBER_SUCCESS, result })
 }
 
-export const removeCardMemberController = async (req: Request<CardMemberParams, any, any>, res: Response) => {
+export const removeCardMemberController = async (req: Request<CardMemberParams>, res: Response) => {
   const { card_id, user_id } = req.params
 
   const result = await cardsService.removeCardMember(card_id, user_id)
@@ -125,7 +125,7 @@ export const reactToCardCommentController = async (
   return res.json({ message: CARDS_MESSAGES.REACT_CARD_COMMENT_SUCCESS, result })
 }
 
-export const deleteCardController = async (req: Request<CardParams, any, any>, res: Response) => {
+export const deleteCardController = async (req: Request<CardParams>, res: Response) => {
   const { card_id } = req.params
   const column_id = (req.card as Card & { column_id: string }).column_id
 

--- a/src/controllers/columns.controllers.ts
+++ b/src/controllers/columns.controllers.ts
@@ -19,7 +19,7 @@ export const updateColumnController = async (req: Request<ColumnParams, any, Upd
   return res.json({ message: COLUMNS_MESSAGES.UPDATE_COLUMN_SUCCESS, result })
 }
 
-export const deleteColumnController = async (req: Request<ColumnParams, any, any>, res: Response) => {
+export const deleteColumnController = async (req: Request<ColumnParams>, res: Response) => {
   const { column_id } = req.params
   const board_id = (req.column as Column & { board_id: string }).board_id
 

--- a/src/controllers/workspaces.controllers.ts
+++ b/src/controllers/workspaces.controllers.ts
@@ -8,6 +8,7 @@ import {
   RemoveGuestFromBoardReqBody,
   RemoveWorkspaceMemberFromBoardReqBody,
   UpdateWorkspaceReqBody,
+  WorkspaceBoardParams,
   WorkspaceGuestParams,
   WorkspaceMemberParams,
   WorkspaceParams
@@ -135,4 +136,13 @@ export const deleteWorkspaceController = async (req: Request<WorkspaceParams, an
   await workspacesService.deleteWorkspace(workspace_id)
 
   return res.json({ message: WORKSPACES_MESSAGES.DELETE_WORKSPACE_SUCCESS })
+}
+
+export const joinWorkspaceBoardController = async (req: Request<WorkspaceBoardParams, any, any>, res: Response) => {
+  const { board_id } = req.params
+  const { user_id } = req.decoded_authorization as TokenPayload
+
+  const result = await workspacesService.joinWorkspaceBoard(board_id, user_id)
+
+  return res.json({ message: WORKSPACES_MESSAGES.JOIN_WORKSPACE_BOARD_SUCCESS, result })
 }

--- a/src/controllers/workspaces.controllers.ts
+++ b/src/controllers/workspaces.controllers.ts
@@ -70,7 +70,7 @@ export const editWorkspaceMemberRoleController = async (
   return res.json({ message: WORKSPACES_MESSAGES.EDIT_WORKSPACE_MEMBER_ROLE_SUCCESS, result })
 }
 
-export const leaveWorkspaceController = async (req: Request<WorkspaceParams, any, any>, res: Response) => {
+export const leaveWorkspaceController = async (req: Request<WorkspaceParams>, res: Response) => {
   const { workspace_id } = req.params
   const { user_id } = req.decoded_authorization as TokenPayload
 
@@ -79,7 +79,7 @@ export const leaveWorkspaceController = async (req: Request<WorkspaceParams, any
   return res.json({ message: WORKSPACES_MESSAGES.LEAVE_WORKSPACE_SUCCESS, result })
 }
 
-export const removeWorkspaceMemberController = async (req: Request<WorkspaceMemberParams, any, any>, res: Response) => {
+export const removeWorkspaceMemberController = async (req: Request<WorkspaceMemberParams>, res: Response) => {
   const { workspace_id, user_id } = req.params
 
   const result = await workspacesService.removeWorkspaceMember(workspace_id, user_id)
@@ -99,7 +99,7 @@ export const removeWorkspaceMemberFromBoardController = async (
   return res.json({ message: WORKSPACES_MESSAGES.REMOVE_WORKSPACE_MEMBER_FROM_BOARD_SUCCESS, result })
 }
 
-export const addGuestToWorkspaceController = async (req: Request<WorkspaceGuestParams, any, any>, res: Response) => {
+export const addGuestToWorkspaceController = async (req: Request<WorkspaceGuestParams>, res: Response) => {
   const { workspace_id, user_id } = req.params
 
   const result = await workspacesService.addGuestToWorkspace(workspace_id, user_id)
@@ -107,10 +107,7 @@ export const addGuestToWorkspaceController = async (req: Request<WorkspaceGuestP
   return res.json({ message: WORKSPACES_MESSAGES.ADD_GUEST_TO_WORKSPACE_SUCCESS, result })
 }
 
-export const removeGuestFromWorkspaceController = async (
-  req: Request<WorkspaceGuestParams, any, any>,
-  res: Response
-) => {
+export const removeGuestFromWorkspaceController = async (req: Request<WorkspaceGuestParams>, res: Response) => {
   const { workspace_id, user_id } = req.params
 
   const result = await workspacesService.removeGuestFromWorkspace(workspace_id, user_id)
@@ -130,7 +127,7 @@ export const removeGuestFromBoardController = async (
   return res.json({ message: WORKSPACES_MESSAGES.REMOVE_GUEST_FROM_BOARD_SUCCESS, result })
 }
 
-export const deleteWorkspaceController = async (req: Request<WorkspaceParams, any, any>, res: Response) => {
+export const deleteWorkspaceController = async (req: Request<WorkspaceParams>, res: Response) => {
   const { workspace_id } = req.params
 
   await workspacesService.deleteWorkspace(workspace_id)
@@ -138,7 +135,7 @@ export const deleteWorkspaceController = async (req: Request<WorkspaceParams, an
   return res.json({ message: WORKSPACES_MESSAGES.DELETE_WORKSPACE_SUCCESS })
 }
 
-export const joinWorkspaceBoardController = async (req: Request<WorkspaceBoardParams, any, any>, res: Response) => {
+export const joinWorkspaceBoardController = async (req: Request<WorkspaceBoardParams>, res: Response) => {
   const { board_id } = req.params
   const { user_id } = req.decoded_authorization as TokenPayload
 

--- a/src/middlewares/boards.middlewares.ts
+++ b/src/middlewares/boards.middlewares.ts
@@ -1,6 +1,6 @@
 import { validate } from '~/utils/validation'
 import { checkSchema, ParamSchema } from 'express-validator'
-import { BOARDS_MESSAGES, WORKSPACES_MESSAGES } from '~/constants/messages'
+import { BOARDS_MESSAGES } from '~/constants/messages'
 import { stringEnumToArray } from '~/utils/commons'
 import { BoardRole, BoardType } from '~/constants/enums'
 import { ObjectId } from 'mongodb'
@@ -130,26 +130,9 @@ export const boardIdValidator = validate(
                     as: 'workspaceData',
                     pipeline: [
                       {
-                        $lookup: {
-                          from: envConfig.dbBoardsCollection,
-                          localField: '_id',
-                          foreignField: 'workspace_id',
-                          as: 'boards',
-                          pipeline: [
-                            {
-                              $project: { title: 1, cover_photo: 1 }
-                            },
-                            {
-                              $match: { _destroy: { $ne: true } }
-                            }
-                          ]
-                        }
-                      },
-                      {
                         $project: {
                           title: 1,
                           logo: 1,
-                          boards: 1,
                           members: 1,
                           guests: 1
                         }

--- a/src/middlewares/invitations.middlewares.ts
+++ b/src/middlewares/invitations.middlewares.ts
@@ -192,7 +192,7 @@ export const createNewBoardInvitationValidator = validate(
   )
 )
 
-export const checkInviteeMembershipValidator = wrapRequestHandler(
+export const verifyInviteeMembershipValidator = wrapRequestHandler(
   async (req: Request, res: Response, next: NextFunction) => {
     const invitee = req.invitee as User
     const board = req.board as Board

--- a/src/middlewares/rbac.middlewares.ts
+++ b/src/middlewares/rbac.middlewares.ts
@@ -118,6 +118,15 @@ export const requireBoardPermissionFromBody = (permission: BoardPermission, fiel
 
     const { user_id } = req.decoded_authorization as TokenPayload
 
+    const isBoardMember = board.members?.some((member) => member.user_id.equals(new ObjectId(user_id)))
+
+    if (!isBoardMember) {
+      throw new ErrorWithStatus({
+        status: HTTP_STATUS.FORBIDDEN,
+        message: BOARDS_MESSAGES.USER_NOT_MEMBER_OF_BOARD
+      })
+    }
+
     const allowed = hasBoardPermission(new ObjectId(user_id), board, permission, workspace)
 
     if (!allowed) {

--- a/src/middlewares/workspaces.middlewares.ts
+++ b/src/middlewares/workspaces.middlewares.ts
@@ -512,3 +512,21 @@ export const removeGuestFromBoardValidator = validate(
     ['body']
   )
 )
+
+export const joinWorkspaceBoardValidator = wrapRequestHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { user_id } = req.decoded_authorization as TokenPayload
+    const board = (req as Request).board
+
+    const isAlreadyBoardMember = board?.members?.some((member) => member.user_id.equals(new ObjectId(user_id)))
+
+    if (isAlreadyBoardMember) {
+      throw new ErrorWithStatus({
+        status: HTTP_STATUS.BAD_REQUEST,
+        message: WORKSPACES_MESSAGES.USER_ALREADY_JOINED_BOARD
+      })
+    }
+
+    next()
+  }
+)

--- a/src/models/requests/Board.requests.ts
+++ b/src/models/requests/Board.requests.ts
@@ -17,6 +17,10 @@ export interface BoardParams extends ParamsDictionary {
   board_id: string
 }
 
+export interface JoinedWorkspaceBoardQuery extends Pagination, Query {
+  workspace_id: string
+}
+
 export interface UpdateBoardReqBody extends CreateBoardReqBody {
   column_order_ids: string[]
   cover_photo?: string

--- a/src/models/requests/Workspace.requests.ts
+++ b/src/models/requests/Workspace.requests.ts
@@ -34,3 +34,7 @@ export interface RemoveWorkspaceMemberFromBoardReqBody {
 export interface RemoveGuestFromBoardReqBody {
   board_id: string
 }
+
+export interface WorkspaceBoardParams extends WorkspaceParams {
+  board_id: string
+}

--- a/src/routes/boards.routes.ts
+++ b/src/routes/boards.routes.ts
@@ -3,6 +3,7 @@ import {
   createBoardController,
   getBoardController,
   getBoardsController,
+  leaveBoardController,
   updateBoardController
 } from '~/controllers/boards.controllers'
 import { accessTokenValidator } from '~/middlewares/auth.middlewares'
@@ -10,6 +11,8 @@ import {
   boardIdValidator,
   createBoardValidator,
   getBoardsValidator,
+  leaveBoardValidator,
+  requireBoardMembership,
   updateBoardValidator
 } from '~/middlewares/boards.middlewares'
 import { filterMiddleware, paginationValidator } from '~/middlewares/common.middlewares'
@@ -51,6 +54,7 @@ boardsRouter.put(
   accessTokenValidator,
   verifiedUserValidator,
   boardIdValidator,
+  requireBoardMembership,
   updateBoardValidator,
   filterMiddleware<UpdateBoardReqBody>([
     'title',
@@ -62,6 +66,16 @@ boardsRouter.put(
   ]),
   requireBoardPermission(BoardPermission.ManageBoard),
   wrapRequestHandler(updateBoardController)
+)
+
+boardsRouter.post(
+  '/:board_id/members/me/leave',
+  accessTokenValidator,
+  verifiedUserValidator,
+  boardIdValidator,
+  requireBoardMembership,
+  leaveBoardValidator,
+  wrapRequestHandler(leaveBoardController)
 )
 
 export default boardsRouter

--- a/src/routes/boards.routes.ts
+++ b/src/routes/boards.routes.ts
@@ -3,6 +3,7 @@ import {
   createBoardController,
   getBoardController,
   getBoardsController,
+  getJoinedWorkspaceBoardsController,
   leaveBoardController,
   updateBoardController
 } from '~/controllers/boards.controllers'
@@ -21,6 +22,7 @@ import { UpdateBoardReqBody } from '~/models/requests/Board.requests'
 import { wrapRequestHandler } from '~/utils/handlers'
 import { requireBoardPermission } from '~/middlewares/rbac.middlewares'
 import { BoardPermission } from '~/constants/permissions'
+import { workspaceIdValidator } from '~/middlewares/workspaces.middlewares'
 
 const boardsRouter = Router()
 
@@ -38,6 +40,14 @@ boardsRouter.get(
   paginationValidator,
   getBoardsValidator,
   wrapRequestHandler(getBoardsController)
+)
+
+boardsRouter.get(
+  '/workspace/:workspace_id',
+  accessTokenValidator,
+  paginationValidator,
+  workspaceIdValidator,
+  wrapRequestHandler(getJoinedWorkspaceBoardsController)
 )
 
 boardsRouter.get(

--- a/src/routes/invitations.routes.ts
+++ b/src/routes/invitations.routes.ts
@@ -11,7 +11,7 @@ import { accessTokenValidator } from '~/middlewares/auth.middlewares'
 import { filterMiddleware, paginationValidator } from '~/middlewares/common.middlewares'
 import {
   boardInvitationUpdateGuard,
-  checkInviteeMembershipValidator,
+  verifyInviteeMembershipValidator,
   createNewBoardInvitationValidator,
   createNewWorkspaceInvitationValidator,
   invitationIdValidator,
@@ -31,7 +31,7 @@ invitationsRouter.post(
   accessTokenValidator,
   verifiedUserValidator,
   createNewWorkspaceInvitationValidator,
-  checkInviteeMembershipValidator,
+  verifyInviteeMembershipValidator,
   wrapRequestHandler(createNewWorkspaceInvitationController)
 )
 
@@ -40,7 +40,7 @@ invitationsRouter.post(
   accessTokenValidator,
   verifiedUserValidator,
   createNewBoardInvitationValidator,
-  checkInviteeMembershipValidator,
+  verifyInviteeMembershipValidator,
   wrapRequestHandler(createNewBoardInvitationController)
 )
 

--- a/src/routes/workspaces.routes.ts
+++ b/src/routes/workspaces.routes.ts
@@ -6,6 +6,7 @@ import {
   editWorkspaceMemberRoleController,
   getWorkspaceController,
   getWorkspacesController,
+  joinWorkspaceBoardController,
   leaveWorkspaceController,
   removeGuestFromBoardController,
   removeGuestFromWorkspaceController,
@@ -26,12 +27,14 @@ import {
   removeWorkspaceMemberValidator,
   removeWorkspaceMemberFromBoardValidator,
   workspaceGuestIdValidator,
-  removeGuestFromBoardValidator
+  removeGuestFromBoardValidator,
+  joinWorkspaceBoardValidator
 } from '~/middlewares/workspaces.middlewares'
 import { UpdateWorkspaceReqBody } from '~/models/requests/Workspace.requests'
 import { wrapRequestHandler } from '~/utils/handlers'
 import { requireWorkspacePermission } from '~/middlewares/rbac.middlewares'
 import { WorkspacePermission } from '~/constants/permissions'
+import { boardIdValidator } from '~/middlewares/boards.middlewares'
 
 const workspacesRouter = Router()
 
@@ -145,6 +148,17 @@ workspacesRouter.delete(
   workspaceIdValidator,
   requireWorkspacePermission(WorkspacePermission.DeleteWorkspace),
   wrapRequestHandler(deleteWorkspaceController)
+)
+
+workspacesRouter.post(
+  '/:workspace_id/join/:board_id',
+  accessTokenValidator,
+  verifiedUserValidator,
+  workspaceIdValidator,
+  boardIdValidator,
+  joinWorkspaceBoardValidator,
+  requireWorkspacePermission(WorkspacePermission.JoinWorkspaceBoard),
+  wrapRequestHandler(joinWorkspaceBoardController)
 )
 
 export default workspacesRouter

--- a/src/services/boards.services.ts
+++ b/src/services/boards.services.ts
@@ -86,6 +86,29 @@ class BoardsService {
 
     return board
   }
+
+  async leaveBoard(board_id: string, user_id: string) {
+    // Step 1: Remove user from board members
+    const board = await databaseService.boards.findOneAndUpdate(
+      { _id: new ObjectId(board_id) },
+      {
+        $pull: { members: { user_id: new ObjectId(user_id) } },
+        $currentDate: { updated_at: true }
+      },
+      { returnDocument: 'after' }
+    )
+
+    // Step 2: Remove user from all cards in this board where the user is a member
+    await databaseService.cards.updateMany(
+      { board_id: new ObjectId(board_id), members: new ObjectId(user_id) },
+      {
+        $pull: { members: new ObjectId(user_id) },
+        $currentDate: { updated_at: true }
+      }
+    )
+
+    return board
+  }
 }
 
 const boardsService = new BoardsService()

--- a/src/services/invitations.services.ts
+++ b/src/services/invitations.services.ts
@@ -346,7 +346,7 @@ class InvitationsService {
       { returnDocument: 'after' }
     )
 
-    // Step 2: If the case is a successful invitation, it is necessary to add more information of the user (UserID) to the member_ids record in the Board collection.
+    // Step 2: If the case is a successful invitation, it is necessary to add more information of the user (UserID) to the `members` array in the Board collection.
     if (body.status === BoardInvitationStatus.Accepted) {
       await databaseService.boards.findOneAndUpdate(
         { _id: new ObjectId(body.board_id) },

--- a/src/services/workspaces.services.ts
+++ b/src/services/workspaces.services.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from 'mongodb'
-import { WorkspaceRole, WorkspaceType } from '~/constants/enums'
+import { BoardRole, WorkspaceRole, WorkspaceType } from '~/constants/enums'
 import {
   CreateWorkspaceReqBody,
   EditWorkspaceMemberRoleReqBody,
@@ -327,6 +327,25 @@ class WorkspacesService {
         $currentDate: { updated_at: true }
       }
     )
+  }
+
+  async joinWorkspaceBoard(board_id: string, user_id: string) {
+    const board = await databaseService.boards.findOneAndUpdate(
+      { _id: new ObjectId(board_id) },
+      {
+        $push: {
+          members: {
+            user_id: new ObjectId(user_id),
+            role: BoardRole.Member,
+            joined_at: new Date()
+          }
+        },
+        $currentDate: { updated_at: true }
+      },
+      { returnDocument: 'after' }
+    )
+
+    return board
   }
 }
 


### PR DESCRIPTION
Purpose
- Enable self-serve board membership management (join/leave) within workspaces
- Provide a paginated endpoint to list boards a user has joined in a workspace
- Tighten authorization with explicit membership checks and a new workspace-level permission
- Improve type safety in controllers and expand RBAC documentation

Key Changes
- Board membership APIs
  - Join board within a workspace (requires appropriate workspace permission)
    - POST /workspaces/:workspace_id/join/:board_id
  - Leave a board (with guard to ensure at least one admin remains)
    - POST /boards/:board_id/members/me/leave
- New boards listing endpoint
  - Get boards the current user has joined in a workspace, with pagination
    - GET /boards/workspace/:workspace_id?limit=&page=
  - Response includes boards, limit, page, and total_page
- Authorization and RBAC
  - Enforces membership checks on sensitive board operations (e.g., updates and invitations)
  - Introduces a new workspace-level permission to allow joining boards from a workspace context
  - Strengthens middleware-based permission and membership validation flows
- Validation and middleware
  - Adds pagination and workspace ID validation for the new listing endpoint
  - Adds a leave-guard validator to prevent the last remaining admin from leaving a board
  - Aligns invitation membership checks and naming
- Type-safety improvements
  - Removes unnecessary any usage in card, column, workspace, and workspace member controllers
  - Minor comment and naming cleanups for clarity
- Messages and UX
  - Adds success and error messages for join/leave and joined workspace boards retrieval
- Documentation
  - Expands Role-Based Access Control documentation (architecture, brief, context) with permission flows and examples

Notes
- Backwards compatibility: Joining a board through the workspace route now requires the new workspace-level permission; ensure role configuration grants it where appropriate.
- No database schema changes; continues to use soft-delete patterns and existing collection structures.
- Pagination is required for the joined-boards endpoint; clients should pass limit and page.

Testing Scenarios
- Join a board where the user is already a member should fail with a clear error message.
- Leave a board as the last admin should be blocked.
- Joined workspace boards endpoint returns only boards the user is a member of, with correct pagination metadata.