### PR TITLE
Add board deletion API, RBAC permission, and real-time socket event

### DIFF
--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -121,7 +121,9 @@ export const BOARDS_MESSAGES = {
   BOARD_ARCHIVE_STATUS_MUST_BE_BOOLEAN: 'Board archive status must be boolean',
   BOARD_IS_CLOSED_REOPEN_REQUIRED: 'Board is closed. Please reopen the board before making changes',
   STATE_MUST_BE_STRING: 'State must be a string',
-  STATE_MUST_BE_CLOSED_OR_ACTIVE: 'State must be "closed" or "active"'
+  STATE_MUST_BE_CLOSED_OR_ACTIVE: 'State must be "closed" or "active"',
+  BOARD_MUST_BE_CLOSED_BEFORE_DELETION: 'Board must be closed before it can be deleted',
+  DELETE_BOARD_SUCCESS: 'Board deleted successfully'
 }
 
 export const COLUMNS_MESSAGES = {

--- a/src/constants/permissions.ts
+++ b/src/constants/permissions.ts
@@ -21,7 +21,8 @@ export enum BoardPermission {
   EditCard = 'BOARD__EDIT_CARD',
   DeleteCard = 'BOARD__DELETE_CARD',
   Comment = 'BOARD__COMMENT',
-  Attach = 'BOARD__ATTACH'
+  Attach = 'BOARD__ATTACH',
+  DeleteBoard = 'BOARD__DELETE'
 }
 
 export const WORKSPACE_ROLE_PERMISSIONS: Record<WorkspaceRole, WorkspacePermission[]> = {
@@ -53,7 +54,8 @@ export const BOARD_ROLE_PERMISSIONS: Record<BoardRole, BoardPermission[]> = {
     BoardPermission.EditCard,
     BoardPermission.DeleteCard,
     BoardPermission.Comment,
-    BoardPermission.Attach
+    BoardPermission.Attach,
+    BoardPermission.DeleteBoard
   ],
   [BoardRole.Member]: [
     BoardPermission.ViewBoard,

--- a/src/controllers/boards.controllers.ts
+++ b/src/controllers/boards.controllers.ts
@@ -83,3 +83,9 @@ export const leaveBoardController = async (req: Request<BoardParams>, res: Respo
 
   return res.json({ message: BOARDS_MESSAGES.LEAVE_BOARD_SUCCESS, result })
 }
+
+export const deleteBoardController = async (req: Request<BoardParams>, res: Response) => {
+  const { board_id } = req.params
+  await boardsService.deleteBoard(board_id)
+  return res.json({ message: BOARDS_MESSAGES.DELETE_BOARD_SUCCESS })
+}

--- a/src/middlewares/rbac.middlewares.ts
+++ b/src/middlewares/rbac.middlewares.ts
@@ -73,16 +73,26 @@ export const requireBoardPermission = (permission: BoardPermission) => {
     const workspace = (board as { workspace?: Workspace }).workspace || null
 
     if (permission !== BoardPermission.ViewBoard) {
-      const body = (req.body || {}) as Record<string, unknown>
+      if (permission === BoardPermission.DeleteBoard) {
+        // Only allow deleting a board if it is already closed
+        if (!board._destroy) {
+          throw new ErrorWithStatus({
+            status: HTTP_STATUS.FORBIDDEN,
+            message: BOARDS_MESSAGES.BOARD_MUST_BE_CLOSED_BEFORE_DELETION
+          })
+        }
+      } else {
+        const body = (req.body || {}) as Record<string, unknown>
 
-      const isReopenAttempt =
-        typeof req.params.board_id === 'string' &&
-        Object.prototype.hasOwnProperty.call(body, '_destroy') &&
-        body._destroy === false &&
-        Object.keys(body).every((key) => key === '_destroy')
+        const isReopenAttempt =
+          typeof req.params.board_id === 'string' &&
+          Object.prototype.hasOwnProperty.call(body, '_destroy') &&
+          body._destroy === false &&
+          Object.keys(body).every((key) => key === '_destroy')
 
-      if (!isReopenAttempt) {
-        assertBoardIsOpen(board)
+        if (!isReopenAttempt) {
+          assertBoardIsOpen(board)
+        }
       }
     }
 

--- a/src/routes/boards.routes.ts
+++ b/src/routes/boards.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import {
   createBoardController,
+  deleteBoardController,
   getBoardController,
   getBoardsController,
   getJoinedWorkspaceBoardsController,
@@ -89,6 +90,16 @@ boardsRouter.post(
   requireBoardMembership,
   leaveBoardValidator,
   wrapRequestHandler(leaveBoardController)
+)
+
+boardsRouter.delete(
+  '/:board_id',
+  accessTokenValidator,
+  verifiedUserValidator,
+  boardIdValidator,
+  requireBoardMembership,
+  requireBoardPermission(BoardPermission.DeleteBoard),
+  wrapRequestHandler(deleteBoardController)
 )
 
 export default boardsRouter

--- a/src/services/boards.services.ts
+++ b/src/services/boards.services.ts
@@ -176,6 +176,58 @@ class BoardsService {
 
     return board
   }
+
+  async deleteBoard(board_id: string) {
+    // Get board to obtain workspace context and members for cleanup
+    const board = await databaseService.boards.findOne({ _id: new ObjectId(board_id) })
+
+    // 1) Delete related invitations to this board
+    await databaseService.invitations.deleteMany({ 'board_invitation.board_id': new ObjectId(board_id) })
+
+    // 2) Delete all cards in the board
+    await databaseService.cards.deleteMany({ board_id: new ObjectId(board_id) })
+
+    // 3) Delete all columns in the board
+    await databaseService.columns.deleteMany({ board_id: new ObjectId(board_id) })
+
+    // 4) Delete the board itself
+    await databaseService.boards.deleteOne({ _id: new ObjectId(board_id) })
+
+    // 5) Cleanup workspace guests for users who no longer belong to any board in this workspace
+    if (board?.workspace_id) {
+      const workspace = await databaseService.workspaces.findOne({ _id: new ObjectId(board.workspace_id) })
+
+      if (workspace) {
+        const memberUserIds = board.members.map((m) => m.user_id)
+
+        for (const userId of memberUserIds) {
+          // Skip if user is a workspace member
+          const isWorkspaceMember = workspace.members.some((m) => m.user_id.equals(new ObjectId(userId)))
+
+          // Skip workspace members because they should remain in the workspace regardless of board membership
+          // Only guests (non-workspace members) should be removed from workspace.guests when they leave all boards
+          if (isWorkspaceMember) continue
+
+          // Check if the user is still a member of any other (open) board in the same workspace
+          const remainingBoardsCount = await databaseService.boards.countDocuments({
+            workspace_id: new ObjectId(board.workspace_id),
+            _destroy: false,
+            'members.user_id': new ObjectId(userId)
+          })
+
+          if (remainingBoardsCount === 0) {
+            await databaseService.workspaces.updateOne(
+              { _id: board.workspace_id },
+              {
+                $pull: { guests: new ObjectId(userId) },
+                $currentDate: { updated_at: true }
+              }
+            )
+          }
+        }
+      }
+    }
+  }
 }
 
 const boardsService = new BoardsService()

--- a/src/sockets/boards.sockets.ts
+++ b/src/sockets/boards.sockets.ts
@@ -27,3 +27,9 @@ export const acceptBoardInvitationSocket = (socket: Socket) => {
     socket.broadcast.to(`board-${boardId}`).emit('SERVER_USER_ACCEPTED_BOARD_INVITATION', invitee)
   })
 }
+
+export const deleteBoardSocket = (socket: Socket) => {
+  socket.on('CLIENT_USER_DELETED_BOARD', (boardId) => {
+    socket.broadcast.to(`board-${boardId}`).emit('SERVER_USER_DELETED_BOARD', boardId)
+  })
+}

--- a/src/utils/socket.ts
+++ b/src/utils/socket.ts
@@ -4,7 +4,12 @@ import { corsOptions } from '~/config/cors'
 import logger from '~/config/logger'
 import { TokenPayload } from '~/models/requests/User.requests'
 import { inviteUserToBoardSocket, inviteUserToWorkspaceSocket } from '~/sockets/invitations.sockets'
-import { manageBoardSocketEvents, updateBoardSocket, acceptBoardInvitationSocket } from '~/sockets/boards.sockets'
+import {
+  manageBoardSocketEvents,
+  updateBoardSocket,
+  acceptBoardInvitationSocket,
+  deleteBoardSocket
+} from '~/sockets/boards.sockets'
 import { updateCardSocket } from '~/sockets/cards.sockets'
 import { verifyAccessToken } from '~/utils/jwt'
 import {
@@ -93,6 +98,7 @@ const initSocket = (httpServer: ServerHttp) => {
     createWorkspaceBoardSocket(socket)
     updateBoardSocket(socket)
     acceptBoardInvitationSocket(socket)
+    deleteBoardSocket(socket)
     updateCardSocket(socket)
 
     socket.on('disconnect', () => {


### PR DESCRIPTION
This PR introduces full support for deleting boards, including API, RBAC, service logic, and real-time socket events. Key changes:

- **API & Routing**
  - Added `DELETE /boards/:board_id` endpoint to [`boards.routes.ts`](src/routes/boards.routes.ts).
  - Integrated with authentication, board membership, and new `DeleteBoard` RBAC permission.

- **RBAC & Permissions**
  - Introduced `BoardPermission.DeleteBoard` in [`permissions.ts`](src/constants/permissions.ts).
  - Only users with this permission (typically Admins) can delete a board.
  - Middleware enforces that a board must be closed (`_destroy: true`) before deletion.

- **Controller & Service**
  - Added [`deleteBoardController`](src/controllers/boards.controllers.ts) and [`boardsService.deleteBoard()`](src/services/boards.services.ts).
  - Service method performs cascading deletion:
    - Removes related invitations, cards, columns.
    - Deletes the board document.
    - Cleans up workspace guests who no longer belong to any board in the workspace.

- **Constants & Messages**
  - Added new messages for board deletion and precondition errors in [`messages.ts`](src/constants/messages.ts).

- **Sockets**
  - Added `CLIENT_USER_DELETED_BOARD` and `SERVER_USER_DELETED_BOARD` events in [`boards.sockets.ts`](src/sockets/boards.sockets.ts) and registered in [`utils/socket.ts`](src/utils/socket.ts) for real-time updates.

- **Other**
  - Updated RBAC middleware logic to enforce board-closed precondition for deletion.
  - Ensured all changes follow project conventions and maintain type safety.

**Important Notes:**
- Deletion is only allowed for closed boards to prevent accidental data loss.
- Guest cleanup ensures workspace guest lists remain accurate after board removal.
- Real-time socket events notify all connected clients of board deletion.

**Testing Evidence:**
- Manual validation: Created, closed, and deleted boards as Admin; verified related data cleanup and socket events.
- Lint and build pass: `npm run lint` and `npm run build` successful.

**Environment Variables:**  
_No changes required._

**Screenshots/API Examples:**  
- Example: `DELETE /boards/64f...` returns `{ message: "Board deleted successfully" }` if preconditions are met.